### PR TITLE
Docs: Adicionando template de pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+# 📌 Descrição da PR
+Forneça informações sobre as mudanças realizadas nesta PR, destacando de forma breve o objetivo principal da modificação.
+
+## 🔗 Link da task
+[Clique aqui para acessar o card da tarefa](link...)
+
+#### Tasks relacionadas
+- link
+
+## 📝 Tipo de mudança
+- [ ] Novo recurso (feature)
+- [ ] Correção de bug
+- [ ] Alteração de UI/UX
+- [ ] Alteração de estilo (CSS)
+- [ ] Refatoração
+- [ ] Alteração crítica (breaking change)
+
+
+## ⚙️ Como foi testado?
+- Navegadores testados: [ ] Chrome  [ ] Firefox  [ ] Safari  [ ] Edge  
+- Responsividade testada? [ ] Sim [ ] Não  
+- Testes unitários (se aplicável).
+- Testes manuais e cenários verificados.
+
+## ✅ Checklist antes do merge
+- [ ] Testado em múltiplos navegadores.
+- [ ] Testado em dispositivos móveis.
+- [ ] Código segue padrões do projeto.
+- [ ] Sem dados sensíveis.
+- [ ] Documentação atualizada (README).


### PR DESCRIPTION
## Mudanças Realizadas
Foi criada a pasta .github contendo o arquivo pull_request_template.md, que define o template padrão para as Pull Requests deste repositório.
O objetivo é padronizar as descrições das PRs, garantindo maior clareza e qualidade.